### PR TITLE
closing and unistalling apps technical limitations for iOS

### DIFF
--- a/docs/Discover Tella/features.md
+++ b/docs/Discover Tella/features.md
@@ -191,8 +191,7 @@ The Delete Tella option might not be available on some Android phones due to tec
 
 By clicking the exit button on Tella’s home screen right top corner, Android users can quickly close and lock the app in case of emergency. While having the lock timeout set to “immediately” means that the app already locks when the user exits, using the Quick Exit button adds an extra layer of security and assurance that the app will be fully closed and locked 🔒
 
-On the iOS platform it is not possible to close the existing app programatically. Tapping ont he quick exit button will only lock Tella.
-
+On iOS, it is not possible to shut down an app from inside the app itself. Tapping the quick exit button instead locks the app.
 
 ## Verification mode
 

--- a/docs/Discover Tella/features.md
+++ b/docs/Discover Tella/features.md
@@ -181,15 +181,17 @@ A Quick Delete button allows users, in just a few seconds, to delete sensitive d
 * Delete vault: Deletes all files stored in Tella 🗑️
 * Delete draft and submitted forms: Deletes drafts and submitted forms in all Open Data Kit (ODK) connected servers 📝
 * Delete server settings: Deletes all server connections and all the forms or templates associated with them 📋
-* Delete Tella: Deletes the app and all the data it contains. It triggers a message asking if the user wants to uninstall Tella as well ❌
+* Delete Tella: Deletes the app and all the data it contains. It triggers a message asking if the user wants to uninstall Tella as well ❌. 
 
 :::info Delete Tella
-The Delete Tella option might not be available on some phones due to technical details. We are working on a fix for this issue. 
+The Delete Tella option might not be available on some Android phones due to technical limitations. We are working on a fix for this issue. For iOS it is not possible to programmatically delete an app. 
 :::
 
 ## Quick exit
 
-By clicking the exit button on Tella’s home screen right top corner, users can quickly close and lock the app in case of emergency. While having the lock timeout set to “immediately” means that the app already locks when the user exits, using the Quick Exit button adds an extra layer of security and assurance that the app will be fully closed and locked 🔒
+By clicking the exit button on Tella’s home screen right top corner, Android users can quickly close and lock the app in case of emergency. While having the lock timeout set to “immediately” means that the app already locks when the user exits, using the Quick Exit button adds an extra layer of security and assurance that the app will be fully closed and locked 🔒
+
+On the iOS platform it is not possible to close the existing app programatically. Tapping ont he quick exit button will only lock Tella.
 
 
 ## Verification mode

--- a/docs/_features-table.md
+++ b/docs/_features-table.md
@@ -18,7 +18,7 @@
 | [Audio Recorder](/features#audio-recorder)| ✔️ | ✔️ | ✔️ |
 | [Open files in Tella](/features#open-files-in-tella)| Photos, videos, audio | Photos, videos, audio, PDF | Photos, videos, audio |
 | [Verification mode](/features#verification-mode)| ✔️ | Not yet | ✔️ |
-| [Quick delete](/features#quick-delete)| ✔️ | ✔️ | ✔️ |
-| [Quick exit](/features#quick-exit)| ✔️ | ✔️ | ✔️ |
+| [Quick delete](/features#quick-delete)| ✔️ | Yes but only files and connections  | ✔️ |
+| [Quick exit](/features#quick-exit)| ✔️ | Only lock (not close) | ✔️ |
 | [Connections to collect data and send files](/features#connecting-to-servers) | - Tella Web <br />- Uwazi <br />- Open Data Kit (Forms) | - Tella Web  | - Uwazi <br />- Open Data Kit (Forms)  |
 | [Offline data collection](/features#offline-data-collection) | ✔️ | ✔️ |  ✔️ |


### PR DESCRIPTION
Hi team! after testing 1.4.0 dhekra and I were talking about these 2 technical limitations not being explicit on the documentation. 

1. In iOS we don't have a way to close the app programmatically, There is an option to put the app in background or quit the app with exit(0)  but I think it's not recommended by Apple and considered as a crash and may Apple reject the app
https://developer.apple.com/library/archive/qa/qa1561/_index.html

2. Programmatically delete the app is not possible https://stackoverflow.com/questions/9811994/is-there-any-way-to-programmatically-delete-my-own-ios-app

Do you both think with these changes is sufficiently clear ? Would you add more details and/or somewhere else on the documentation?