### PR TITLE
Tella web 1.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ yarn
 ### Local Development {#local-development}
 
 ```
-$ yarn start
+$ PRODUCTION_URL='http://localhost' yarn start --locale en
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.

--- a/docs/Discover Tella/security-and-privacy.md
+++ b/docs/Discover Tella/security-and-privacy.md
@@ -38,7 +38,7 @@ As a result of Apple’s strict iOS app policies, Tella for iOS is currently not
 
 In Tella Android and [Tella Web](/tella-web), users can choose to share analytics to improve Tella. This data helps us understand how people use Tella and which features are important to them. ***Analytics data is only collected if users opt-in in the app's settings***
 
-We use [Divvi Up](https://divviup.org/), a privacy-respecting system for analytics. Divvi Up is implemented by the [Internet Security Research Group (ISRG)](https://www.abetterinternet.org/), which also maintains the [Let’s Encrypt](https://letsencrypt.org/) project. 
+We use [Divvi Up](https://divviup.org/), a privacy-respecting telemetry service. Divvi Up is implemented by the [Internet Security Research Group (ISRG)](https://www.abetterinternet.org/), a nonprofit organization that also maintains the [Let’s Encrypt](https://letsencrypt.org/) project. 
 
 Here are some information about our privacy-preserving analytics approach:
 

--- a/docs/For organizations/tella-web.md
+++ b/docs/For organizations/tella-web.md
@@ -62,7 +62,8 @@ Admins of the Tella Web space can enable or disable system-wide settings dependi
 - Suspicious login detection: 
     - If enabled Tella Web will record location for each login IP and approximate location based on IP. If the user is connecting from an unusual location Tella Web will block the login attempt to prevent any unauthorized sing-in and send an email to the user to confirm if was a legitimate login attempt. 
     - IPs and location will not be shared with the Tella team and will only be stored in the server where Tella Web is installed.
-    - Tella Web requires an SMTP server to be properly configured and working for this feature to work.
+    - Tella Web requires an SMTP server to be properly configured and working for this feature to work. 
+    - If disabled Tella Web won't store the IP, won't calculate location nor ping any third party service.
 - Feedback:
     - When enabled, Tella Web shows a feedback box that allow users to send an anonymous note to the Tella team on any feedback request or bug reports that they might find. It doesn't contain any information about the user or the Tella Web instance.
     - To ensure user privacy and anonymity, only essential data is transmitted to our Feedback server through HTTPS POST requests. Logs containing user information (IP address, date and time, and user-agent) are automatically deleted weekly.

--- a/docs/For organizations/tella-web.md
+++ b/docs/For organizations/tella-web.md
@@ -33,7 +33,7 @@ Setting up Tella Web involves three steps, which are thoroughly discussed in thi
 
 This step consists of installing and configuring Tella Web on the server your organization will be using. This step needs to be completed by the person who is going to be responsible for the system administration (a developer or a system administrator). Technical instructions can be found on [our Github](https://github.com/Horizontal-org/tellaweb).
 
-You can check Tella Web release notes [here](https://github.com/Horizontal-org/TellaWeb-FrontEnd/releases).
+You can check Tella Web release notes [here](https://github.com/Horizontal-org/tellaweb/releases).
 
 
 :::info
@@ -57,13 +57,16 @@ Take a look at [this video tutorial](/video-tutorials#connections-full-video) fo
 
 ### Admin center {#admin-center}
 
-Admins of the Tella Web space can enable or disable system-wide settings:
+Admins of the Tella Web space can enable or disable system-wide settings depending on their own risk assessment and privacy consideration:
 - [Opt-in to share analytics with Tella team](/security-and-privacy#analytics).
-- Supicious login detection: 
+- Suspicious login detection: 
     - If enabled Tella Web will record location for each login IP and approximate location based on IP. If the user is connecting from an unusual location Tella Web will block the login attempt to prevent any unauthorized sing-in and send an email to the user to confirm if was a legitimate login attempt. 
+    - IPs and location will not be shared with the Tella team and will only be stored in the server where Tella Web is installed.
     - Tella Web requires an SMTP server to be properly configured and working for this feature to work.
 - Feedback:
-    - When enabled, Tella Web show a feedback box that send an anonymous note to the Tella team on any feedback request or bug reports that the user might find. It doesn't contain any information about the user or the Tella Web instance, but it does require an an SMTP server to be properly configured and working for this feature to work. 
+    - When enabled, Tella Web shows a feedback box that allow users to send an anonymous note to the Tella team on any feedback request or bug reports that they might find. It doesn't contain any information about the user or the Tella Web instance.
+    - To ensure user privacy and anonymity, only essential data is transmitted to our Feedback server through HTTPS POST requests. Logs containing user information (IP address, date and time, and user-agent) are automatically deleted weekly.
+    - On the Feedback server database, we only store a copy of the text sent by users in the feedback form and which platform it came from (in this case from "Tella Web" without specifying which server installation). 
 
 
 

--- a/docs/For organizations/tella-web.md
+++ b/docs/For organizations/tella-web.md
@@ -61,7 +61,7 @@ Admins of the Tella Web space can enable or disable system-wide settings dependi
 - [Opt-in to share analytics with Tella team](/security-and-privacy#analytics).
 - Suspicious login detection: 
     - If enabled Tella Web will record location for each login IP and approximate location based on IP. If the user is connecting from an unusual location Tella Web will block the login attempt to prevent any unauthorized sing-in and send an email to the user to confirm if was a legitimate login attempt. 
-    - IPs and location will not be shared with the Tella team and will only be stored in the server where Tella Web is installed.
+    - We use a [third party server](https://ipinfo.io/) to calculate the country of the IP. 
     - Tella Web requires an SMTP server to be properly configured and working for this feature to work. 
     - If disabled Tella Web won't store the IP, won't calculate location nor ping any third party service.
 - Feedback:

--- a/docs/For organizations/tella-web.md
+++ b/docs/For organizations/tella-web.md
@@ -57,8 +57,14 @@ Take a look at [this video tutorial](/video-tutorials#connections-full-video) fo
 
 ### Admin center {#admin-center}
 
-Admins of the Tella Web space can change system-wide settings:
+Admins of the Tella Web space can enable or disable system-wide settings:
 - [Opt-in to share analytics with Tella team](/security-and-privacy#analytics).
+- Supicious login detection: 
+    - If enabled Tella Web will record location for each login IP and approximate location based on IP. If the user is connecting from an unusual location Tella Web will block the login attempt to prevent any unauthorized sing-in and send an email to the user to confirm if was a legitimate login attempt. 
+    - Tella Web requires an SMTP server to be properly configured and working for this feature to work.
+- Feedback:
+    - When enabled, Tella Web show a feedback box that send an anonymous note to the Tella team on any feedback request or bug reports that the user might find. It doesn't contain any information about the user or the Tella Web instance, but it does require an an SMTP server to be properly configured and working for this feature to work. 
+
 
 
 ### Managing Projects {#managing-projects}


### PR DESCRIPTION
@juandans01 @raphmim I wrote here the documentation about the admin center feature!

I wrote about "suspicious login" feature even though we don't have it individualized yet because it is individualized in the contract: https://horizontal-org.slite.com/app/docs/d9juVOhYj-QJYH

I don't like the idea of enabling or disabling EMAILS (in general) . I feel  that's more like an infra-configuration(that we already wrote about in the README about the smtp variables). For exmple in the future if we implement restore password or any other thing that requires email I don't want admins to mistakenly disable "emails" and disable multiple features without knowing what are they are doing.

Could you please review if what I wrote makes sense for now, and once @raphmim review the figma and make a decision on labels I can adapt those.

Could you both please:
- check if the release url is correct or if there is any other place or change that we want to make to the "Install the server" part ? 
- review if the privacy considerations for the features on the admin centar are correct: the goal is for admins to have what they need to make an informed decision about if it's safe for them to enable those in their servers


Gracias!!
